### PR TITLE
add aggregated_search_terms_daily

### DIFF
--- a/contextual_services/explores/aggregated_search_terms_daily.explore.lkml
+++ b/contextual_services/explores/aggregated_search_terms_daily.explore.lkml
@@ -1,0 +1,12 @@
+include: "/looker-hub/contextual_services/views/aggregated_search_terms_daily.view.lkml"
+
+explore: aggregated_search_terms_daily {
+  sql_always_where: ${aggregated_search_terms_daily.submission_date} >= '2010-01-01' ;;
+  view_name: aggregated_search_terms_daily
+
+  always_filter: {
+    filters: [
+      submission_date: "28 days",
+    ]
+  }
+}

--- a/contextual_services/views/aggregated_search_terms_daily.view.lkml
+++ b/contextual_services/views/aggregated_search_terms_daily.view.lkml
@@ -1,0 +1,42 @@
+view: aggregated_search_terms_daily {
+  dimension: search_terms {
+    sql: ${TABLE}.search_terms ;;
+    type: string
+    description: Search terms entered into the urlbar, possibly sanitized.
+  }
+
+  dimension_group: submission {
+    sql: ${TABLE}.submission_date ;;
+    type: time
+    timeframes: [
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+  }
+
+  measure: impressions {
+    type: sum
+    sql: ${TABLE}.impressions ;;
+    label: "Impression Count"
+    description: "Count of Firefox Suggest impressions shown for this search term."
+  }
+
+  measure: clicks {
+    type: sum
+    sql: ${TABLE}.clicks ;;
+    label: "Click Count"
+    description: "Count of clicks on Firefox Suggest suggestions shown for this search term."
+  }
+
+  measure: client_days {
+    type: sum
+    sql: ${TABLE}.client_days ;;
+    label: "Client-Day Count"
+    description: "Count of clients who searched for this search term. If the same client searched for this search term on multiple days within the specified timerange, then that client is counted multiple times. (This is NOT a count of unique clients.)"
+  }
+
+  sql_table_name: `mozdata.search_terms.aggregated_search_terms_daily` ;;
+}

--- a/contextual_services/views/aggregated_search_terms_daily.view.lkml
+++ b/contextual_services/views/aggregated_search_terms_daily.view.lkml
@@ -2,7 +2,7 @@ view: aggregated_search_terms_daily {
   dimension: search_terms {
     sql: ${TABLE}.search_terms ;;
     type: string
-    description: Search terms entered into the urlbar, possibly sanitized.
+    description: "Search terms entered into the urlbar, possibly sanitized."
   }
 
   dimension_group: submission {


### PR DESCRIPTION
Trying to add aggregated_search_terms_daily as a new dataset / view to Looker, but this seems to have made all the Contextual Services default explores disappear when I check the front end.