### PR TITLE
Only making escape_metachars(property_value.value) when filter specified

### DIFF
--- a/mozilla_vpn/views/funnel_analysis.view.lkml
+++ b/mozilla_vpn/views/funnel_analysis.view.lkml
@@ -102,7 +102,7 @@ view: funnel_analysis {
 
 view: event_types {
   derived_table: {
-    sql: SELECT mozfun.event_analysis.aggregate_match_strings( ARRAY_AGG(CONCAT(COALESCE({% if _filters['property_value'] %} mozfun.event_analysis.escape_metachars(property_value.value), {% endif %} ''), mozfun.event_analysis.event_index_to_match_string(et.index)))) AS match_string FROM `mozdata.mozilla_vpn.event_types` as et LEFT JOIN UNNEST(COALESCE(event_properties, [])) AS properties LEFT JOIN UNNEST(properties.value) AS property_value WHERE {% condition category %} category {% endcondition %} AND {% condition event %} event {% endcondition %} AND {% condition property_name %} properties.key {% endcondition %} AND {% condition property_value %} property_value.key {% endcondition %} ;;
+    sql: SELECT mozfun.event_analysis.aggregate_match_strings( ARRAY_AGG(DISTINCT CONCAT({% if _filters['property_name'] or _filters['property_value'] -%} COALESCE(mozfun.event_analysis.escape_metachars(property_value.value), ''), {% endif -%} mozfun.event_analysis.event_index_to_match_string(et.index)))) AS match_string FROM `mozdata.mozilla_vpn.event_types` as et LEFT JOIN UNNEST(COALESCE(event_properties, [])) AS properties LEFT JOIN UNNEST(properties.value) AS property_value WHERE {% condition category %} category {% endcondition %} AND {% condition event %} event {% endcondition %} AND {% condition property_name %} properties.key {% endcondition %} AND {% condition property_value %} property_value.key {% endcondition %} ;;
   }
 
   filter: category {

--- a/mozilla_vpn/views/funnel_analysis.view.lkml
+++ b/mozilla_vpn/views/funnel_analysis.view.lkml
@@ -102,7 +102,7 @@ view: funnel_analysis {
 
 view: event_types {
   derived_table: {
-    sql: SELECT mozfun.event_analysis.aggregate_match_strings( ARRAY_AGG(CONCAT(COALESCE(mozfun.event_analysis.escape_metachars(property_value.value), ''),mozfun.event_analysis.event_index_to_match_string(et.index)))) AS match_string FROM `mozdata.mozilla_vpn.event_types` as et LEFT JOIN UNNEST(COALESCE(event_properties, [])) AS properties LEFT JOIN UNNEST(properties.value) AS property_value WHERE {% condition category %} category {% endcondition %} AND {% condition event %} event {% endcondition %} AND {% condition property_name %} properties.key {% endcondition %} AND {% condition property_value %} property_value.key {% endcondition %} ;;
+    sql: SELECT mozfun.event_analysis.aggregate_match_strings( ARRAY_AGG(CONCAT(COALESCE({% if property_value.value %} mozfun.event_analysis.escape_metachars(property_value.value), {% endif %} ''), mozfun.event_analysis.event_index_to_match_string(et.index)))) AS match_string FROM `mozdata.mozilla_vpn.event_types` as et LEFT JOIN UNNEST(COALESCE(event_properties, [])) AS properties LEFT JOIN UNNEST(properties.value) AS property_value WHERE {% condition category %} category {% endcondition %} AND {% condition event %} event {% endcondition %} AND {% condition property_name %} properties.key {% endcondition %} AND {% condition property_value %} property_value.key {% endcondition %} ;;
   }
 
   filter: category {

--- a/mozilla_vpn/views/funnel_analysis.view.lkml
+++ b/mozilla_vpn/views/funnel_analysis.view.lkml
@@ -102,7 +102,7 @@ view: funnel_analysis {
 
 view: event_types {
   derived_table: {
-    sql: SELECT mozfun.event_analysis.aggregate_match_strings( ARRAY_AGG(CONCAT(COALESCE({% if property_value.value %} mozfun.event_analysis.escape_metachars(property_value.value), {% endif %} ''), mozfun.event_analysis.event_index_to_match_string(et.index)))) AS match_string FROM `mozdata.mozilla_vpn.event_types` as et LEFT JOIN UNNEST(COALESCE(event_properties, [])) AS properties LEFT JOIN UNNEST(properties.value) AS property_value WHERE {% condition category %} category {% endcondition %} AND {% condition event %} event {% endcondition %} AND {% condition property_name %} properties.key {% endcondition %} AND {% condition property_value %} property_value.key {% endcondition %} ;;
+    sql: SELECT mozfun.event_analysis.aggregate_match_strings( ARRAY_AGG(CONCAT(COALESCE({% if _filters['property_value'] %} mozfun.event_analysis.escape_metachars(property_value.value), {% endif %} ''), mozfun.event_analysis.event_index_to_match_string(et.index)))) AS match_string FROM `mozdata.mozilla_vpn.event_types` as et LEFT JOIN UNNEST(COALESCE(event_properties, [])) AS properties LEFT JOIN UNNEST(properties.value) AS property_value WHERE {% condition category %} category {% endcondition %} AND {% condition event %} event {% endcondition %} AND {% condition property_name %} properties.key {% endcondition %} AND {% condition property_value %} property_value.key {% endcondition %} ;;
   }
 
   filter: category {


### PR DESCRIPTION
Only making escape_metachars(property_value.value) when filter specified.

This change should not be merged here. This was only done to be able to work directly in Looker to demonstrate that this change allows to produce results.

If we're happy with implementing this change (and don't think there's _downstream impact_) it should be added here:
https://github.com/mozilla/lookml-generator/blob/4c72682d0288462e75d1f48ffc1c34a8222494a1/generator/views/funnel_analysis_view.py#L162