### PR TITLE
Remove reference to now-deleted BQ view

### DIFF
--- a/namespaces.yaml
+++ b/namespaces.yaml
@@ -204,10 +204,6 @@ ads:
       tables:
       - table: mozdata.ads.consolidated_ad_metrics_daily_pt
       type: table_view
-    consolidated_ad_metrics_hourly:
-      tables:
-      - table: mozdata.ads.consolidated_ad_metrics_hourly
-      type: table_view
 awesome_bar:
   explores:
     urlbar_clients_daily:


### PR DESCRIPTION
This view was delete from BigQuery because it was redundant, so we need to remove it from the namespace here as well