### PR TITLE
DENG-2674 Remove cost view from namespaces

### DIFF
--- a/namespaces.yaml
+++ b/namespaces.yaml
@@ -5063,10 +5063,6 @@ monitoring:
       tables:
       - table: moz-fx-data-shared-prod.monitoring.bigquery_usage
       type: table_view
-    bigquery_usage_costs:
-      tables:
-      - table: moz-fx-data-shared-prod.monitoring.bigquery_usage_costs
-      type: table_view
     column_size:
       tables:
       - table: mozdata.monitoring.column_size


### PR DESCRIPTION
This view is to be removed:  https://github.com/mozilla/bigquery-etl/pull/4991