### PR TITLE
Remove active_users_aggregates_attribution from Looker.

### DIFF
--- a/namespaces.yaml
+++ b/namespaces.yaml
@@ -325,10 +325,6 @@ combined_browser_metrics:
       tables:
       - table: moz-fx-data-shared-prod.telemetry.active_users_aggregates
       type: table_view
-    active_users_aggregates_attribution:
-      tables:
-      - table: moz-fx-data-shared-prod.telemetry.active_users_aggregates_attribution
-      type: table_view
     active_users_aggregates_device:
       tables:
       - table: moz-fx-data-shared-prod.telemetry.active_users_aggregates_device


### PR DESCRIPTION
Required for deprecation in [DENG-3966](https://mozilla-hub.atlassian.net/browse/DENG-3966).